### PR TITLE
Made TopNav and Modals keyboard accessible

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react": "^15.3.2",
     "react-addons-css-transition-group": "^15.3.2",
     "react-dom": "^15.3.2",
+    "react-focus-trap": "^2.3.3",
     "react-router": "^2.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,10 +54,10 @@
   },
   "dependencies": {
     "babel-polyfill": "^6.16.0",
+    "focus-trap-react": "^3.0.1",
     "react": "^15.3.2",
     "react-addons-css-transition-group": "^15.3.2",
     "react-dom": "^15.3.2",
-    "react-focus-trap": "^2.3.3",
     "react-router": "^2.8.1"
   }
 }

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react'
 import './Modal.scss'
 import Backdrop from '../common/backdrop/Backdrop'
+import FocusTrap from 'react-focus-trap'
 
 class Modal extends React.Component {
   constructor(props, context) {
@@ -23,16 +24,18 @@ class Modal extends React.Component {
     const { content, imgSrc, title } = this.props
     return (
       <Backdrop key="modal" className="Modal-container" onClick={this.hide} hidden={this.state.hidden}>
-        <div className="Modal">
-          <button className="Modal_button" onClick={this.props.hide}>X</button>
-          <div className="Modal_header">
-            <img className="Modal_image" src={imgSrc} alt={title + ' logo'}/>
-            <h2>{title}</h2>
+        <FocusTrap>
+          <div className="Modal">
+            <button className="Modal_button" onClick={this.hide}>X</button>
+            <div className="Modal_header">
+              <img className="Modal_image" src={imgSrc} alt={title + ' logo'}/>
+              <h2>{title}</h2>
+            </div>
+            <div className="Modal_content">
+              {content}
+            </div>
           </div>
-          <div className="Modal_content">
-            {content}
-          </div>
-        </div>
+        </FocusTrap>
       </Backdrop>
     )
   }

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -24,7 +24,11 @@ class Modal extends React.Component {
     const { content, imgSrc, title } = this.props
     return (
       <Backdrop key="modal" className="Modal-container" onClick={this.hide} hidden={this.state.hidden}>
-        <FocusTrap>
+        <FocusTrap
+          focusTrapOptions={{
+            onDeactivate: this.hide,
+            clickOutsideDeactivates: true
+          }}>
           <div className="Modal">
             <button className="Modal_button" onClick={this.hide}>X</button>
             <div className="Modal_header">

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react'
 import './Modal.scss'
 import Backdrop from '../common/backdrop/Backdrop'
-import FocusTrap from 'react-focus-trap'
+import FocusTrap from 'focus-trap-react'
 
 class Modal extends React.Component {
   constructor(props, context) {

--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -31,7 +31,7 @@ box-shadow: 0px 0px 27px 0px rgba(0,0,0,0.4);
   overflow: hidden;
 }
 .modal-enter .Modal, .modal-leave-active .Modal{
-  transform: translate(140vw);
+  transform: translate(250%);
 }
 .Modal_button {
   position: absolute;

--- a/src/components/common/killFocus/KillFocus.js
+++ b/src/components/common/killFocus/KillFocus.js
@@ -1,0 +1,40 @@
+import React, { PropTypes } from 'react'
+import getFocusable from './getFocusable'
+
+class KillFocus extends React.Component {
+  constructor(props, ctx) {
+    super(props, ctx)
+
+    this.focusable = null
+
+    this.getFocusable = this.getFocusable.bind(this)
+    this.setTabIndex = this.setTabIndex.bind(this)
+  }
+  componentDidMount() {
+    this.setTabIndex(this.props.enabled)
+  }
+  componentWillReceiveProps(newProps) {
+    this.setTabIndex(newProps.enabled)
+  }
+  getFocusable(elem) {
+    const search = elem.node || elem
+    this.focusable = Array.prototype.slice.apply(getFocusable(search))
+  }
+  setTabIndex(enabled) {
+    const tabIndex = enabled ? '-1' : '0'
+
+    this.focusable.forEach(elem => {
+      elem.tabIndex = tabIndex
+    })
+  }
+  render() {
+    return React.cloneElement(this.props.children, {
+      ref: this.getFocusable
+    })
+  }
+}
+KillFocus.propTypes = {
+  enabled: PropTypes.bool,
+  children: PropTypes.element
+}
+export default KillFocus;

--- a/src/components/common/killFocus/KillFocus.test.js
+++ b/src/components/common/killFocus/KillFocus.test.js
@@ -1,0 +1,77 @@
+import React from 'react'
+import expect from 'expect'
+import { shallow, mount } from 'enzyme'
+
+import KillFocus from './KillFocus'
+
+describe("killFocus", function () {
+  /*
+  * children must be a single root element which will be
+  * searched for any focusable elements
+  */
+  it("renders children when enabled = true", function () {
+    const wrapper = shallow(
+      <KillFocus enabled>
+        <div>
+          <input />
+        </div>
+      </KillFocus>
+    )
+
+    expect(wrapper.find('input').length).toEqual(1)
+  });
+  describe("adds proper tabIndex to inputs", function () {
+    it("when enabled = false", function () {
+      const wrapper = mount(
+        <KillFocus>
+          <div>
+            <input />
+          </div>
+        </KillFocus>
+      )
+      const input = wrapper.find('input')
+
+      expect(input.node.tabIndex).toEqual('0')
+    });
+    it("when enabled = true", function () {
+      const wrapper = mount(
+        <KillFocus enabled>
+          <div>
+            <input />
+          </div>
+        </KillFocus>
+      )
+      const input = wrapper.find('input')
+
+      expect(input.node.tabIndex).toEqual('-1')
+    });
+    it("when enabled is changed from true to false", function () {
+      const wrapper = mount(
+        <KillFocus enabled>
+          <div>
+            <input />
+          </div>
+        </KillFocus>
+      )
+      const input = wrapper.find('input')
+
+      wrapper.setProps({enabled: false})
+
+      expect(input.node.tabIndex).toEqual('0')
+    });
+    it("when enabled is changed from false to true", function () {
+      const wrapper = mount(
+        <KillFocus>
+          <div>
+            <input />
+          </div>
+        </KillFocus>
+      )
+      const input = wrapper.find('input')
+
+      wrapper.setProps({enabled: true})
+
+      expect(input.node.tabIndex).toEqual('-1')
+    });
+  });
+});

--- a/src/components/common/killFocus/getFocusable.js
+++ b/src/components/common/killFocus/getFocusable.js
@@ -1,0 +1,12 @@
+export default function getFocusable(elem) {
+  const isTabbable = [
+    'input',
+    'select',
+    'a[href]',
+    'textarea',
+    'button',
+    '[tabindex]'
+  ]
+
+  return elem.querySelectorAll(isTabbable)
+}

--- a/src/components/common/topnav/TopNav.js
+++ b/src/components/common/topnav/TopNav.js
@@ -5,6 +5,9 @@ import NavLinks from './NavLinks'
 import FabList from '../FabList/FabList'
 import NavFooter from './NavFooter'
 
+import FocusTrap from 'focus-trap-react'
+import KillFocus from '../killFocus/KillFocus'
+
 import { navLinks, socialLinks } from '../../../store/links'
 import logoSrc from '../../../assets/images/logo.png'
 
@@ -16,23 +19,41 @@ class TopNav extends Component {
       isOpen: false
     }
     this.toggleNav = this.toggleNav.bind(this)
+    this.closeNav = this.closeNav.bind(this)
+  }
+  closeNav() {
+    this.setState({isOpen: false})
   }
   toggleNav() {
     this.setState({isOpen: !this.state.isOpen})
   }
   render() {
+    const { isOpen } = this.state
     return (
-      <Backdrop hidden={!this.state.isOpen} onClick={this.toggleNav} duration="200" cssTimingFunc="linear">
-      <nav className={'TopNav' + (this.state.isOpen ? '' : ' hidden')}>
+      <Backdrop
+        tabIndex="-1"
+        hidden={!isOpen}
+        onClick={this.closeNav}
+        duration="200"
+        cssTimingFunc="linear" >
+      <nav className={'TopNav' + (isOpen ? '' : ' hidden')}>
         <button className="TopNav_toggleButton" onClick={this.toggleNav} />
-        <div className="TopNav_content">
-          <div className="TopNav_content_logo">
-            <img src={logoSrc} alt="logo-jmc-in-block-letters"/>
-          </div>
-          <NavLinks links={navLinks} classes="TopNav_content_NavLinks" delay={150}/>
-          <FabList links={socialLinks} className="TopNav_content_socialLinks"/>
-          <NavFooter />
-        </div>
+        <KillFocus enabled={!isOpen}>
+          <FocusTrap
+            className="TopNav_content"
+            active={isOpen}
+            focusTrapOptions={{
+              onDeactivate: this.closeNav,
+              clickOutsideDeactivates: true
+            }}>
+            <div className="TopNav_content_logo">
+              <img src={logoSrc} alt="logo-jmc-in-block-letters"/>
+            </div>
+            <NavLinks links={navLinks} classes="TopNav_content_NavLinks" delay={150}/>
+            <FabList links={socialLinks} className="TopNav_content_socialLinks"/>
+            <NavFooter />
+          </FocusTrap>
+        </KillFocus>
       </nav>
       </Backdrop>
     )

--- a/src/components/common/topnav/TopNav.scss
+++ b/src/components/common/topnav/TopNav.scss
@@ -5,7 +5,9 @@ $border: 1px solid $backgroundIndent;
 
 $animSpeed: 0.2s;
 $transition: $animSpeed linear;
-
+.TopNav_content-wrapper {
+  height: 100%;
+}
 .TopNav {
   z-index: 999;
   position: fixed;
@@ -31,7 +33,7 @@ $transition: $animSpeed linear;
     background: darken($background, 5%);
     border: 1px solid $textColor;
     border: none;
-    outline: none;
+    // outline: none;
     -webkit-tap-highlight-color: transparent;
     cursor: pointer;
     border-radius: 29% 33% 36% 35%;

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,10 @@
 	<title>React Portfolio</title>
 	<meta name="viewport" content="user-scalable=no, initial-scale=1.0, maximum-scale=1.0, width=device-width"/>
 	<link href="https://fonts.googleapis.com/css?family=Roboto|Roboto+Slab" rel="stylesheet">
+	<style id="poot"></style>
 </head>
-<body>
+<body
+  onmousedown="document.getElementById('poot').innerHTML='a, input, select, a[href], textarea, button {outline:none}';"
+	onkeydown="document.getElementById('poot').innerHTML=''">>
 </body>
 </html>


### PR DESCRIPTION
* added focus-trap-react as a dependency 
* added focus trap to modal
* created KillFocus component which toggles tabIndex on focusable elements
* added focus trap and KillFocus to TopNav so that it can’t be focused when not visible
* added event listeners to body which enable or disable the outline of focused element depending on wether mouse or keyboard is being used